### PR TITLE
Ability to submit shooting phase with ranged attacks

### DIFF
--- a/client/src/lib/components/sandbox/play/phase-input/PhaseInput.svelte
+++ b/client/src/lib/components/sandbox/play/phase-input/PhaseInput.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import MovementPhaseInput from './MovementPhaseInput.svelte';
+	import ShootingPhaseInput from './ShootingPhaseInput.svelte';
 
 	export let game: Game;
 	export let currentPlayer: string;
@@ -18,5 +19,7 @@
 	</div>
 	{#if game.currentPhase?.name == 'MOVEMENT'}
 		<MovementPhaseInput {game} {currentPlayer} {rerender} />
+	{:else if game.currentPhase?.name == 'SHOOTING'}
+		<ShootingPhaseInput {game} {currentPlayer} {rerender} />
 	{/if}
 </div>

--- a/client/src/lib/components/sandbox/play/phase-input/ShootingPhaseInput.svelte
+++ b/client/src/lib/components/sandbox/play/phase-input/ShootingPhaseInput.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+	import { MinaArenaClient } from '$lib/mina-arena-graphql-client/MinaArenaClient';
+
+	export let game: Game;
+	export let currentPlayer: string;
+	export let rerender: () => {};
+
+	const minaArenaClient = new MinaArenaClient();
+
+	const playerPieces = game.gamePieces.filter((p) => {
+		return p.gamePlayer.player.minaPublicKey === currentPlayer;
+	});
+
+  const enemyPieces = game.gamePieces.filter((p) => {
+		return p.gamePlayer.player.minaPublicKey !== currentPlayer;
+	});
+
+  let rangedAttacks: Record<string, RangedAttackAction> = {};
+
+  const updateRangedAttackTarget = (e: Event, p: GamePiece) => {
+    const target = e.target as HTMLInputElement;
+    const targetGamePieceId = target.valueAsNumber;
+
+    if (rangedAttacks[p.id]) {
+      rangedAttacks[p.id].action.targetGamePieceId = targetGamePieceId;
+    } else {
+      rangedAttacks[p.id] = {
+        gamePieceId: p.id,
+        action: {
+          targetGamePieceId: targetGamePieceId,
+          diceRoll: {
+            publicKey: { x: 'xValue', y: 'yValue' },
+            cipherText: 'supersecret',
+            signature: { r: 'rValue', s: 'sValue' },
+          }
+        }
+      }
+    }
+
+    // ??
+    // rangedAttacks = rangedAttacks;
+  }
+
+	const submitPhase = async () => {
+		await minaArenaClient.submitShootingPhase(
+			currentPlayer,
+			game.id,
+			game.currentPhase!.id,
+			Object.values(rangedAttacks)
+		);
+		await rerender();
+	};
+
+	const calculateDistance = (p: GamePiece) => {
+    const rangedAttack = rangedAttacks[p.id];
+		if (rangedAttack) {
+      const targetGamePieceId = rangedAttack.action.targetGamePieceId;
+      const targetPiece = enemyPieces.find(enemyPiece => enemyPiece.id.toString() === targetGamePieceId.toString());
+
+      if (targetPiece) {
+        return Math.sqrt(
+          (p.coordinates.x - targetPiece.coordinates.x) ** 2 +
+            (p.coordinates.y - targetPiece.coordinates.y) ** 2
+        ).toFixed(2);
+      } else {
+        return 'Not found!';
+      }
+		} else {
+			return 0;
+		}
+	};
+</script>
+
+<br>
+<div>
+	<table>
+		<tr>
+			<th>Your Piece</th>
+			<th>Current Location</th>
+			<th>Max Range</th>
+			<th>Target Piece</th>
+			<th>Distance</th>
+		</tr>
+		{#each playerPieces || [] as piece}
+			<tr>
+				<td>{piece.playerUnit.name || 'Bob'} ({piece.playerUnit.unit.name}, ID: {piece.id})</td>
+				<td>{piece.coordinates.x}, {piece.coordinates.y}</td>
+        {#if piece.playerUnit.unit.rangedNumAttacks }
+          <td>{piece.playerUnit.unit.rangedRange}</td>
+        {:else}
+          <td>No ranged attack</td>
+        {/if}
+				<td>
+          ID: <input class="_input w-16" type="number" on:change={(e) => updateRangedAttackTarget(e, piece)} />
+				</td>
+				<td>{#key rangedAttacks}{calculateDistance(piece)}{/key}</td>
+			</tr>
+		{/each}
+	</table>
+  <br>
+  <table>
+    <tr>
+			<th>Enemy Piece</th>
+			<th>Current Location</th>
+      <th>Armor Save</th>
+      <th>Health</th>
+		</tr>
+    {#each enemyPieces || [] as piece}
+			<tr>
+				<td>{piece.playerUnit.name || 'Bob'} ({piece.playerUnit.unit.name}, ID: {piece.id})</td>
+				<td>{piece.coordinates.x}, {piece.coordinates.y}</td>
+				<td>{piece.playerUnit.unit.armorSaveRoll}+</td>
+				<td>{piece.health}/{piece.playerUnit.unit.maxHealth}</td>
+			</tr>
+		{/each}
+  </table>
+	<button on:click={submitPhase}>Submit</button>
+</div>

--- a/client/src/lib/components/sandbox/play/phase-input/ShootingPhaseInput.svelte
+++ b/client/src/lib/components/sandbox/play/phase-input/ShootingPhaseInput.svelte
@@ -78,6 +78,10 @@
 			<th>Your Piece</th>
 			<th>Current Location</th>
 			<th>Max Range</th>
+      <th>Hit</th>
+      <th>Wound</th>
+      <th>AP</th>
+      <th>Damage</th>
 			<th>Target Piece</th>
 			<th>Distance</th>
 		</tr>
@@ -87,8 +91,16 @@
 				<td>{piece.coordinates.x}, {piece.coordinates.y}</td>
         {#if piece.playerUnit.unit.rangedNumAttacks }
           <td>{piece.playerUnit.unit.rangedRange}</td>
+          <td>{piece.playerUnit.unit.rangedHitRoll}+</td>
+          <td>{piece.playerUnit.unit.rangedWoundRoll}+</td>
+          <td>{piece.playerUnit.unit.rangedArmorPiercing}</td>
+          <td>{piece.playerUnit.unit.rangedDamage}</td>
         {:else}
           <td>No ranged attack</td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
         {/if}
 				<td>
           ID: <input class="_input w-16" type="number" on:change={(e) => updateRangedAttackTarget(e, piece)} />

--- a/client/src/lib/components/sandbox/play/phase-input/ShootingPhaseInput.svelte
+++ b/client/src/lib/components/sandbox/play/phase-input/ShootingPhaseInput.svelte
@@ -36,9 +36,6 @@
         }
       }
     }
-
-    // ??
-    // rangedAttacks = rangedAttacks;
   }
 
 	const submitPhase = async () => {

--- a/client/src/lib/mina-arena-graphql-client/MinaArenaClient.ts
+++ b/client/src/lib/mina-arena-graphql-client/MinaArenaClient.ts
@@ -162,4 +162,43 @@ export class MinaArenaClient {
 
     return data.id;
   }
+
+  async submitShootingPhase(
+    player: string,
+    gameId: number,
+    phaseId: number,
+    rangedAttacks: Array<RangedAttackAction>
+  ): Promise<number> {
+    const actions = rangedAttacks.map((rangedAttack) => {
+      return {
+        actionType: 'RANGED_ATTACK',
+        gamePieceId: rangedAttack.gamePieceId,
+        rangedAttackInput: rangedAttack.action
+      }
+    });
+    const mutationInput = {
+      minaPublicKey: player,
+      gameId,
+      actions
+    };
+
+    await this.client.mutate({
+      mutation: CreateGamePieceActionsMut,
+      variables: {
+        input: mutationInput
+      }
+    });
+
+    const { data } = await this.client.mutate({
+      mutation: SubmitGamePhaseMut,
+      variables: {
+        input: {
+          minaPublicKey: player,
+          gamePhaseId: phaseId
+        }
+      }
+    });
+
+    return data.id;
+  }
 }

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -10,7 +10,7 @@ type Game = {
   turnNumber?: number;
   currentPhase?: GamePhase;
   gamePlayers?: Array<GamePlayer>;
-  gamePieces?: Array<GamePiece>;
+  gamePieces: Array<GamePiece>;
   arena?: {
     width: number;
     height: number;
@@ -126,4 +126,28 @@ type MoveAction = {
       y: number;
     }
   }
+}
+
+type RangedAttackAction = {
+  gamePieceId: number;
+  action: {
+    targetGamePieceId: number;
+    diceRoll: DiceRollInput;
+  }
+};
+
+type DiceRollInput = {
+  publicKey: PublicKeyGroup;
+  cipherText: string;
+  signature: Signature;
+};
+
+type PublicKeyGroup = {
+  x: string;
+  y: string;
+};
+
+type Signature = {
+  r: string;
+  s: string;
 }


### PR DESCRIPTION
## Problem

We don't yet have any rendering of the shooting phase on the client, nor do we support submission of any ranged attacks.

## Solution

Add template to render during shooting phase, add support for submitting ranged attacks.

## Notes

A PR to `mina-arena-server` will update it to include all 3 move/shoot/melee phases, it's currently just movement phase back and forth.

![Screen Shot 2023-05-24 at 10 12 26 PM](https://github.com/trumpet-zk-ignite-1/mina-arena/assets/8811423/4a388544-4ffd-40c0-ae8c-22e7a5549dda)

Prime: @45930 