### PR TITLE
Ability to submit melee phase with melee attacks

### DIFF
--- a/client/src/lib/components/sandbox/play/phase-input/MeleePhaseInput.svelte
+++ b/client/src/lib/components/sandbox/play/phase-input/MeleePhaseInput.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { MinaArenaClient } from '$lib/mina-arena-graphql-client/MinaArenaClient';
 
+	// TODO: Pull from server package
+	const MELEE_ATTACK_RANGE = 24;
+
 	export let game: Game;
 	export let currentPlayer: string;
 	export let rerender: () => {};
@@ -86,7 +89,7 @@
 			<tr>
 				<td>{piece.playerUnit.name || 'Bob'} ({piece.playerUnit.unit.name}, ID: {piece.id})</td>
 				<td>{piece.coordinates.x}, {piece.coordinates.y}</td>
-        <td>5</td>
+        <td>{MELEE_ATTACK_RANGE}</td>
         <td>{piece.playerUnit.unit.meleeHitRoll}+</td>
         <td>{piece.playerUnit.unit.meleeWoundRoll}+</td>
         <td>{piece.playerUnit.unit.meleeArmorPiercing}</td>

--- a/client/src/lib/components/sandbox/play/phase-input/MeleePhaseInput.svelte
+++ b/client/src/lib/components/sandbox/play/phase-input/MeleePhaseInput.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+	import { MinaArenaClient } from '$lib/mina-arena-graphql-client/MinaArenaClient';
+
+	export let game: Game;
+	export let currentPlayer: string;
+	export let rerender: () => {};
+
+	const minaArenaClient = new MinaArenaClient();
+
+	const playerPieces = game.gamePieces.filter((p) => {
+		return p.gamePlayer.player.minaPublicKey === currentPlayer;
+	});
+
+  const enemyPieces = game.gamePieces.filter((p) => {
+		return p.gamePlayer.player.minaPublicKey !== currentPlayer;
+	});
+
+  let meleeAttacks: Record<string, MeleeAttackAction> = {};
+
+  const updateMeleeAttackTarget = (e: Event, p: GamePiece) => {
+    const target = e.target as HTMLInputElement;
+    const targetGamePieceId = target.valueAsNumber;
+
+    if (meleeAttacks[p.id]) {
+      meleeAttacks[p.id].action.targetGamePieceId = targetGamePieceId;
+    } else {
+      meleeAttacks[p.id] = {
+        gamePieceId: p.id,
+        action: {
+          targetGamePieceId: targetGamePieceId,
+          diceRoll: {
+            publicKey: { x: 'xValue', y: 'yValue' },
+            cipherText: 'supersecret',
+            signature: { r: 'rValue', s: 'sValue' },
+          }
+        }
+      }
+    }
+  }
+
+	const submitPhase = async () => {
+		await minaArenaClient.submitMeleePhase(
+			currentPlayer,
+			game.id,
+			game.currentPhase!.id,
+			Object.values(meleeAttacks)
+		);
+		await rerender();
+	};
+
+	const calculateDistance = (p: GamePiece) => {
+    const meleeAttack = meleeAttacks[p.id];
+		if (meleeAttack) {
+      const targetGamePieceId = meleeAttack.action.targetGamePieceId;
+      const targetPiece = enemyPieces.find(enemyPiece => enemyPiece.id.toString() === targetGamePieceId.toString());
+
+      if (targetPiece) {
+        return Math.sqrt(
+          (p.coordinates.x - targetPiece.coordinates.x) ** 2 +
+            (p.coordinates.y - targetPiece.coordinates.y) ** 2
+        ).toFixed(2);
+      } else {
+        return 'Not found!';
+      }
+		} else {
+			return 0;
+		}
+	};
+</script>
+
+<br>
+<div>
+	<table>
+		<tr>
+			<th>Your Piece</th>
+			<th>Current Location</th>
+			<th>Max Range</th>
+      <th>Hit</th>
+      <th>Wound</th>
+      <th>AP</th>
+      <th>Damage</th>
+			<th>Target Piece</th>
+			<th>Distance</th>
+		</tr>
+		{#each playerPieces || [] as piece}
+			<tr>
+				<td>{piece.playerUnit.name || 'Bob'} ({piece.playerUnit.unit.name}, ID: {piece.id})</td>
+				<td>{piece.coordinates.x}, {piece.coordinates.y}</td>
+        <td>5</td>
+        <td>{piece.playerUnit.unit.meleeHitRoll}+</td>
+        <td>{piece.playerUnit.unit.meleeWoundRoll}+</td>
+        <td>{piece.playerUnit.unit.meleeArmorPiercing}</td>
+        <td>{piece.playerUnit.unit.meleeDamage}</td>
+				<td>
+          ID: <input class="_input w-16" type="number" on:change={(e) => updateMeleeAttackTarget(e, piece)} />
+				</td>
+				<td>{#key meleeAttacks}{calculateDistance(piece)}{/key}</td>
+			</tr>
+		{/each}
+	</table>
+  <br>
+  <table>
+    <tr>
+			<th>Enemy Piece</th>
+			<th>Current Location</th>
+      <th>Armor Save</th>
+      <th>Health</th>
+		</tr>
+    {#each enemyPieces || [] as piece}
+			<tr>
+				<td>{piece.playerUnit.name || 'Bob'} ({piece.playerUnit.unit.name}, ID: {piece.id})</td>
+				<td>{piece.coordinates.x}, {piece.coordinates.y}</td>
+				<td>{piece.playerUnit.unit.armorSaveRoll}+</td>
+				<td>{piece.health}/{piece.playerUnit.unit.maxHealth}</td>
+			</tr>
+		{/each}
+  </table>
+	<button on:click={submitPhase}>Submit</button>
+</div>

--- a/client/src/lib/components/sandbox/play/phase-input/PhaseInput.svelte
+++ b/client/src/lib/components/sandbox/play/phase-input/PhaseInput.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import MovementPhaseInput from './MovementPhaseInput.svelte';
 	import ShootingPhaseInput from './ShootingPhaseInput.svelte';
+	import MeleePhaseInput from './MeleePhaseInput.svelte';
 
 	export let game: Game;
 	export let currentPlayer: string;
@@ -21,5 +22,7 @@
 		<MovementPhaseInput {game} {currentPlayer} {rerender} />
 	{:else if game.currentPhase?.name == 'SHOOTING'}
 		<ShootingPhaseInput {game} {currentPlayer} {rerender} />
+	{:else if game.currentPhase?.name == 'MELEE'}
+		<MeleePhaseInput {game} {currentPlayer} {rerender} />
 	{/if}
 </div>

--- a/client/src/lib/mina-arena-graphql-client/MinaArenaClient.ts
+++ b/client/src/lib/mina-arena-graphql-client/MinaArenaClient.ts
@@ -201,4 +201,43 @@ export class MinaArenaClient {
 
     return data.id;
   }
+
+  async submitMeleePhase(
+    player: string,
+    gameId: number,
+    phaseId: number,
+    meleeAttacks: Array<MeleeAttackAction>
+  ): Promise<number> {
+    const actions = meleeAttacks.map((meleeAttack) => {
+      return {
+        actionType: 'MELEE_ATTACK',
+        gamePieceId: meleeAttack.gamePieceId,
+        meleeAttackInput: meleeAttack.action
+      }
+    });
+    const mutationInput = {
+      minaPublicKey: player,
+      gameId,
+      actions
+    };
+
+    await this.client.mutate({
+      mutation: CreateGamePieceActionsMut,
+      variables: {
+        input: mutationInput
+      }
+    });
+
+    const { data } = await this.client.mutate({
+      mutation: SubmitGamePhaseMut,
+      variables: {
+        input: {
+          minaPublicKey: player,
+          gamePhaseId: phaseId
+        }
+      }
+    });
+
+    return data.id;
+  }
 }

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -136,6 +136,14 @@ type RangedAttackAction = {
   }
 };
 
+type MeleeAttackAction = {
+  gamePieceId: number;
+  action: {
+    targetGamePieceId: number;
+    diceRoll: DiceRollInput;
+  }
+};
+
 type DiceRollInput = {
   publicKey: PublicKeyGroup;
   cipherText: string;


### PR DESCRIPTION
## Problem

Just like #14 but for melee phase.

## Solution

Support submission of melee phase with melee attacks.

## Notes

In testing this I noticed that dead pieces are still rendered on the board, and they should probably also be excluded from the list of units you can give orders to. A follow-up PR will handle that.

Also I may need to modify the max melee range constant from 5 to something a bit larger. 5 means you have to be practically right on top of them.

![Screen Shot 2023-05-24 at 10 32 04 PM](https://github.com/trumpet-zk-ignite-1/mina-arena/assets/8811423/578966f3-acf8-4ca7-87ae-c44b197abdbe)

Prime: @45930 
