### PR TITLE
Do not render dead pieces, allow removal of queued attacks

### DIFF
--- a/client/src/lib/components/sandbox/play/Arena.svelte
+++ b/client/src/lib/components/sandbox/play/Arena.svelte
@@ -24,11 +24,13 @@
 		offsetTop = canvas.offsetTop;
 		offsetLeft = canvas.offsetLeft;
 		pieces =
-			game.gamePieces?.map((p) => {
-				const owner = p.gamePlayer.player.minaPublicKey;
-				const ownerIdx = players?.indexOf(owner) || 0;
-				return makePiece(p.coordinates.x, p.coordinates.y, 20, 20, legendConfig.colors[ownerIdx]);
-			}) || [];
+			game.gamePieces
+				.filter((p) => p.health > 0)
+				.map((p) => {
+					const owner = p.gamePlayer.player.minaPublicKey;
+					const ownerIdx = players?.indexOf(owner) || 0;
+					return makePiece(p.coordinates.x, p.coordinates.y, 20, 20, legendConfig.colors[ownerIdx]);
+				});
 		console.log(pieces);
 		drawAllPieces(canvas, ctx, pieces);
 	});

--- a/client/src/lib/components/sandbox/play/phase-input/MeleePhaseInput.svelte
+++ b/client/src/lib/components/sandbox/play/phase-input/MeleePhaseInput.svelte
@@ -7,12 +7,14 @@
 
 	const minaArenaClient = new MinaArenaClient();
 
-	const playerPieces = game.gamePieces.filter((p) => {
-		return p.gamePlayer.player.minaPublicKey === currentPlayer;
+	const livingPlayerPieces = game.gamePieces.filter((p) => {
+		return p.gamePlayer.player.minaPublicKey === currentPlayer &&
+           p.health > 0;
 	});
 
-  const enemyPieces = game.gamePieces.filter((p) => {
-		return p.gamePlayer.player.minaPublicKey !== currentPlayer;
+  const livingEnemyPieces = game.gamePieces.filter((p) => {
+		return p.gamePlayer.player.minaPublicKey !== currentPlayer &&
+           p.health > 0;
 	});
 
   let meleeAttacks: Record<string, MeleeAttackAction> = {};
@@ -52,7 +54,7 @@
     const meleeAttack = meleeAttacks[p.id];
 		if (meleeAttack) {
       const targetGamePieceId = meleeAttack.action.targetGamePieceId;
-      const targetPiece = enemyPieces.find(enemyPiece => enemyPiece.id.toString() === targetGamePieceId.toString());
+      const targetPiece = livingEnemyPieces.find(enemyPiece => enemyPiece.id.toString() === targetGamePieceId.toString());
 
       if (targetPiece) {
         return Math.sqrt(
@@ -82,7 +84,7 @@
 			<th>Target Piece</th>
 			<th>Distance</th>
 		</tr>
-		{#each playerPieces || [] as piece}
+		{#each livingPlayerPieces as piece}
 			<tr>
 				<td>{piece.playerUnit.name || 'Bob'} ({piece.playerUnit.unit.name}, ID: {piece.id})</td>
 				<td>{piece.coordinates.x}, {piece.coordinates.y}</td>
@@ -106,7 +108,7 @@
       <th>Armor Save</th>
       <th>Health</th>
 		</tr>
-    {#each enemyPieces || [] as piece}
+    {#each livingEnemyPieces as piece}
 			<tr>
 				<td>{piece.playerUnit.name || 'Bob'} ({piece.playerUnit.unit.name}, ID: {piece.id})</td>
 				<td>{piece.coordinates.x}, {piece.coordinates.y}</td>

--- a/client/src/lib/components/sandbox/play/phase-input/MeleePhaseInput.svelte
+++ b/client/src/lib/components/sandbox/play/phase-input/MeleePhaseInput.svelte
@@ -24,8 +24,16 @@
     const targetGamePieceId = target.valueAsNumber;
 
     if (meleeAttacks[p.id]) {
-      meleeAttacks[p.id].action.targetGamePieceId = targetGamePieceId;
+      // Overwriting a queued attack
+      if (targetGamePieceId) {
+        // With a new target
+        meleeAttacks[p.id].action.targetGamePieceId = targetGamePieceId;
+      } else {
+        // With no target
+        delete meleeAttacks[p.id];
+      }
     } else {
+      // Creating queued attack
       meleeAttacks[p.id] = {
         gamePieceId: p.id,
         action: {

--- a/client/src/lib/components/sandbox/play/phase-input/MovementPhaseInput.svelte
+++ b/client/src/lib/components/sandbox/play/phase-input/MovementPhaseInput.svelte
@@ -7,8 +7,9 @@
 
 	const minaArenaClient = new MinaArenaClient();
 
-	const playerPieces = game.gamePieces?.filter((p) => {
-		return p.gamePlayer.player.minaPublicKey === currentPlayer;
+	const livingPlayerPieces = game.gamePieces.filter((p) => {
+		return p.gamePlayer.player.minaPublicKey === currentPlayer &&
+					 p.health > 0;
 	});
 
 	let moves: Record<string, MoveAction> = {};
@@ -90,7 +91,7 @@
 			<th>Move To Input</th>
 			<th>Distance</th>
 		</tr>
-		{#each playerPieces || [] as piece}
+		{#each livingPlayerPieces as piece}
 			<tr>
 				<td>{piece.playerUnit.name || 'Bob'} the {piece.playerUnit.unit.name}</td>
 				<td>{piece.coordinates.x}, {piece.coordinates.y}</td>
@@ -99,9 +100,7 @@
 					x: <input class="_input w-16" type="number" on:change={(e) => updateMoveX(e, piece)} />
 					y: <input class="_input w-16" type="number" on:change={(e) => updateMoveY(e, piece)} />
 				</td>
-				<td
-					>{#key moves}{calculateDistance(piece)}{/key}</td
-				>
+				<td>{#key moves}{calculateDistance(piece)}{/key}</td>
 			</tr>
 		{/each}
 	</table>

--- a/client/src/lib/components/sandbox/play/phase-input/ShootingPhaseInput.svelte
+++ b/client/src/lib/components/sandbox/play/phase-input/ShootingPhaseInput.svelte
@@ -24,8 +24,16 @@
     const targetGamePieceId = target.valueAsNumber;
 
     if (rangedAttacks[p.id]) {
-      rangedAttacks[p.id].action.targetGamePieceId = targetGamePieceId;
+      // Overwriting a queued attack
+      if (targetGamePieceId) {
+        // With a new target
+        rangedAttacks[p.id].action.targetGamePieceId = targetGamePieceId;
+      } else {
+        // With no target
+        delete rangedAttacks[p.id];
+      }
     } else {
+      // Creating queued attack
       rangedAttacks[p.id] = {
         gamePieceId: p.id,
         action: {

--- a/client/src/lib/components/sandbox/play/phase-input/ShootingPhaseInput.svelte
+++ b/client/src/lib/components/sandbox/play/phase-input/ShootingPhaseInput.svelte
@@ -7,12 +7,14 @@
 
 	const minaArenaClient = new MinaArenaClient();
 
-	const playerPieces = game.gamePieces.filter((p) => {
-		return p.gamePlayer.player.minaPublicKey === currentPlayer;
+	const livingPlayerPieces = game.gamePieces.filter((p) => {
+		return p.gamePlayer.player.minaPublicKey === currentPlayer &&
+           p.health > 0;
 	});
 
-  const enemyPieces = game.gamePieces.filter((p) => {
-		return p.gamePlayer.player.minaPublicKey !== currentPlayer;
+  const livingEnemyPieces = game.gamePieces.filter((p) => {
+		return p.gamePlayer.player.minaPublicKey !== currentPlayer &&
+           p.health > 0;
 	});
 
   let rangedAttacks: Record<string, RangedAttackAction> = {};
@@ -52,7 +54,7 @@
     const rangedAttack = rangedAttacks[p.id];
 		if (rangedAttack) {
       const targetGamePieceId = rangedAttack.action.targetGamePieceId;
-      const targetPiece = enemyPieces.find(enemyPiece => enemyPiece.id.toString() === targetGamePieceId.toString());
+      const targetPiece = livingEnemyPieces.find(enemyPiece => enemyPiece.id.toString() === targetGamePieceId.toString());
 
       if (targetPiece) {
         return Math.sqrt(
@@ -82,7 +84,7 @@
 			<th>Target Piece</th>
 			<th>Distance</th>
 		</tr>
-		{#each playerPieces || [] as piece}
+		{#each livingPlayerPieces as piece}
 			<tr>
 				<td>{piece.playerUnit.name || 'Bob'} ({piece.playerUnit.unit.name}, ID: {piece.id})</td>
 				<td>{piece.coordinates.x}, {piece.coordinates.y}</td>
@@ -114,7 +116,7 @@
       <th>Armor Save</th>
       <th>Health</th>
 		</tr>
-    {#each enemyPieces || [] as piece}
+    {#each livingEnemyPieces as piece}
 			<tr>
 				<td>{piece.playerUnit.name || 'Bob'} ({piece.playerUnit.unit.name}, ID: {piece.id})</td>
 				<td>{piece.coordinates.x}, {piece.coordinates.y}</td>


### PR DESCRIPTION
## Problem

We render all GamePieces regardless of whether they're living or dead. We also show all living and dead GamePieces in the list of pieces you can give orders to or target for attacks, which is wrong.

Also, if you enter the ID of an enemy piece you want to attack, and then clear out the input box, it does not currently remove the queued attack, it just modifies the queued attack to have a target piece ID of `null` which results in the phase submission being rejected.

## Solution

Only render living GamePieces, and only include living GamePieces in the list of pieces you can give orders to or target. Handle clearing of target piece input box.

![Screen Shot 2023-05-24 at 10 49 39 PM](https://github.com/trumpet-zk-ignite-1/mina-arena/assets/8811423/a7214cf3-acb5-4c1f-aeea-f8949979b316)

Prime: @45930 