### PR TITLE
Render game pieces as circles

### DIFF
--- a/client/src/lib/components/sandbox/play/Arena.svelte
+++ b/client/src/lib/components/sandbox/play/Arena.svelte
@@ -16,6 +16,7 @@
 		colors: ['pink', 'lightblue']
 	};
 
+	// TODO: Can different units have different sizes?
 	export const PIECE_RADIUS = 12;
 
 	const players = game.gamePlayers?.map((p) => p.player.minaPublicKey) || ['', ''];

--- a/client/src/lib/components/sandbox/play/Arena.svelte
+++ b/client/src/lib/components/sandbox/play/Arena.svelte
@@ -16,6 +16,8 @@
 		colors: ['pink', 'lightblue']
 	};
 
+	export const PIECE_RADIUS = 12;
+
 	const players = game.gamePlayers?.map((p) => p.player.minaPublicKey) || ['', ''];
 
 	afterUpdate(() => {
@@ -29,7 +31,7 @@
 				.map((p) => {
 					const owner = p.gamePlayer.player.minaPublicKey;
 					const ownerIdx = players?.indexOf(owner) || 0;
-					return makePiece(p.coordinates.x, p.coordinates.y, 20, 20, legendConfig.colors[ownerIdx]);
+					return makePiece(p.coordinates.x, p.coordinates.y, PIECE_RADIUS, legendConfig.colors[ownerIdx]);
 				});
 		console.log(pieces);
 		drawAllPieces(canvas, ctx, pieces);

--- a/client/src/lib/components/sandbox/play/utils.ts
+++ b/client/src/lib/components/sandbox/play/utils.ts
@@ -1,11 +1,8 @@
-export const makePiece = (x: number, y: number, width: number, height: number, fill: string) => {
+export const makePiece = (x: number, y: number, radius: number, fill: string) => {
   const piece = {
     x: x,
     y: y,
-    width: width,
-    height: height,
-    right: x + width,
-    bottom: y + height,
+    radius: radius,
     fill: fill
   };
   return piece;
@@ -23,10 +20,9 @@ export const drawAllPieces = (canvas: HTMLCanvasElement, ctx: CanvasRenderingCon
 };
 
 export const drawPiece = (ctx: CanvasRenderingContext2D, piece: DrawnPiece) => {
+  // TODO: Can different units have different sizes?
+  const radius = 12;
+
   ctx.beginPath();
-  ctx.moveTo(piece.x, piece.y);
-  ctx.lineTo(piece.x + piece.width, piece.y);
-  ctx.lineTo(piece.x + piece.width, piece.y + piece.height);
-  ctx.lineTo(piece.x, piece.y + piece.height);
-  ctx.closePath();
+  ctx.arc(piece.x, piece.y, radius, 0, 2 * Math.PI, false);
 };

--- a/client/src/lib/components/sandbox/play/utils.ts
+++ b/client/src/lib/components/sandbox/play/utils.ts
@@ -20,9 +20,6 @@ export const drawAllPieces = (canvas: HTMLCanvasElement, ctx: CanvasRenderingCon
 };
 
 export const drawPiece = (ctx: CanvasRenderingContext2D, piece: DrawnPiece) => {
-  // TODO: Can different units have different sizes?
-  const radius = 12;
-
   ctx.beginPath();
-  ctx.arc(piece.x, piece.y, radius, 0, 2 * Math.PI, false);
+  ctx.arc(piece.x, piece.y, piece.radius, 0, 2 * Math.PI, false);
 };

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -109,8 +109,7 @@ type CreateGamePieceInput = {
 type DrawnPiece = {
   x: number;
   y: number;
-  width: number;
-  height: number;
+  radius: number;
   fill: string;
 };
 


### PR DESCRIPTION
## Problem

GamePieces are currently rendered as squares, positioned with their top-left corner on the point of the piece's coordinates. We will ultimately probably want units to be circles, likely with some image filled in such as a character portrait or a simple icon indicating which unit it is.

## Solution

Draw pieces as circles centered on the point at which the piece's coordinates are.

<img width="540" alt="Screen Shot 2023-05-25 at 8 05 57 PM" src="https://github.com/trumpet-zk-ignite-1/mina-arena/assets/8811423/c3b731ca-705e-4e06-881c-d854c66b1aa0">

Prime: @45930 