### PR TITLE
Add game over state

### DIFF
--- a/client/src/lib/components/sandbox/play/MainGamePage.svelte
+++ b/client/src/lib/components/sandbox/play/MainGamePage.svelte
@@ -7,12 +7,13 @@
 	import Arena from './Arena.svelte';
 	import { truncateMinaPublicKey } from '$lib/utils';
 
-	let currentGame: Game = { id: Number($page.params.gameId) };
+	let gameId = Number($page.params.gameId);
+	let currentGame: Game;
 	const minaArenaClient = new MinaArenaClient();
 	let loaded = false;
 
 	onMount(async () => {
-		currentGame = await minaArenaClient.getGame(currentGame.id);
+		currentGame = await minaArenaClient.getGame(gameId);
 		console.log(currentGame);
 		loaded = true;
 	});
@@ -29,8 +30,12 @@
 <div>
 	{#if loaded}
 		{#key currentGame}
-			<div>It's your turn: {truncateMinaPublicKey(currentPlayer())}</div>
-			<PhaseInput game={currentGame} currentPlayer={currentPlayer()} {rerender} />
+			{#if currentGame.status === 'IN_PROGRESS'}
+				<div>It's your turn: {truncateMinaPublicKey(currentPlayer())}</div>
+				<PhaseInput game={currentGame} currentPlayer={currentPlayer()} {rerender} />
+			{:else if currentGame.status === 'COMPLETED'}
+				<div><b>GAME OVER!</b> Winner: {currentGame.winningGamePlayer?.player.minaPublicKey}</div>
+			{/if}
 			<Arena game={currentGame} />
 		{/key}
 	{/if}

--- a/client/src/lib/mina-arena-graphql-client/queries/get-game.ts
+++ b/client/src/lib/mina-arena-graphql-client/queries/get-game.ts
@@ -29,6 +29,11 @@ export const GetGameQuery = gql`
           minaPublicKey
         }
       }
+      winningGamePlayer {
+        player {
+          minaPublicKey
+        }
+      }
       gamePieces {
         id
         gamePlayer {

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -10,6 +10,7 @@ type Game = {
   turnNumber?: number;
   currentPhase?: GamePhase;
   gamePlayers?: Array<GamePlayer>;
+  winningGamePlayer?: GamePlayer;
   gamePieces: Array<GamePiece>;
   arena?: {
     width: number;


### PR DESCRIPTION
## Problem

Currently if you play a game to its conclusion (all pieces dead on one side) the UI just renders the "current phase" and all its inputs and doesn't indicate the game is over, even though if you look at the API response from the server it does show that the game has status `COMPLETED`.

## Solution

Add a very basic "game over" state to display when the game is done, and don't allow the user to input more orders.

Obviously this is ugly currently but it does get us to a place where you can play a game to the end and see who won!

Prime: @45930 

<img width="1170" alt="Screen Shot 2023-05-26 at 8 21 28 AM" src="https://github.com/trumpet-zk-ignite-1/mina-arena/assets/8811423/c098c7ad-3365-4788-9e10-845cbd19c011">
