### PR TITLE
Display piece details on hover, allow selecting piece

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -31,7 +31,7 @@
   overflow: hidden;
   border: 1px solid black;
   border-radius: 6px;
-  padding: 4px;
+  padding: 5px;
 }
 
 @layer utilities {

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -25,15 +25,6 @@
   pointer-events: none;
 }
 
-#piece-hover-tooltip {
-  display: none;
-  position: fixed;
-  overflow: hidden;
-  border: 1px solid black;
-  border-radius: 6px;
-  padding: 5px;
-}
-
 @layer utilities {
   ._button {
     border: 1px solid rgb(46, 52, 58);

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -25,6 +25,15 @@
   pointer-events: none;
 }
 
+#piece-hover-tooltip {
+  display: none;
+  position: fixed;
+  overflow: hidden;
+  border: 1px solid black;
+  border-radius: 6px;
+  padding: 4px;
+}
+
 @layer utilities {
   ._button {
     border: 1px solid rgb(46, 52, 58);

--- a/client/src/lib/components/sandbox/play/Arena.svelte
+++ b/client/src/lib/components/sandbox/play/Arena.svelte
@@ -7,7 +7,7 @@
 	let gamePieces: Array<GamePiece> = game.gamePieces;
 
 	let canvas: HTMLCanvasElement;
-	let ctx: CanvasRenderingContext2D;
+	let canvasContext: CanvasRenderingContext2D;
 	let drawnPieces: Array<DrawnPiece> = [];
 
 	let arenaWidth: number = game.arena.width;
@@ -26,6 +26,8 @@
 	const players = game.gamePlayers?.map((p) => p.player.minaPublicKey) || ['', ''];
 
 	onMount(() => {
+		canvas = document.getElementById('canvas') as HTMLCanvasElement;
+		canvasContext = canvas.getContext('2d')!;
 		const livingGamePieces = game.gamePieces.filter((p) => p.health > 0)
 		drawnPieces = livingGamePieces.map((p) => {
 			const owner = p.gamePlayer.player.minaPublicKey;
@@ -35,9 +37,7 @@
 	});
 
 	afterUpdate(() => {
-		canvas = document.getElementById('canvas') as HTMLCanvasElement;
-		ctx = canvas.getContext('2d')!;
-		Utils.drawAllPieces(canvas, ctx, drawnPieces, hoveredPiece, selectedPiece);
+		Utils.drawAllPieces(canvas, canvasContext, drawnPieces, hoveredPiece, selectedPiece);
 	});
 
 	const onMouseMove = (e: MouseEvent) => {
@@ -54,7 +54,6 @@
 	const onMouseUp = (e: MouseEvent) => {
 		const mouseCanvasPoint = Utils.getMouseCanvasPoint(e, canvas);
 		selectedPiece = Utils.pieceAtCanvasPoint(mouseCanvasPoint, drawnPieces, gamePieces);
-		// hoveredPiece = Utils.pieceAtCanvasPoint(mouseCanvasPoint, drawnPieces, gamePieces);
 	}
 
 	const showHoveredPieceTooltip = (absolutePoint: Point) => {
@@ -109,7 +108,7 @@
 				<div>Missile Range: {hoveredUnit.rangedRange}</div>
 			{/if}
 			{#if selectedPiece}
-				<div>Selected: {selectedPiece.id}</div>
+				<div></div>
 			{/if}
 		{/if}
 	</span>

--- a/client/src/lib/components/sandbox/play/Arena.svelte
+++ b/client/src/lib/components/sandbox/play/Arena.svelte
@@ -97,7 +97,7 @@
 			Player 2: {truncateMinaPublicKey(players[1])}
 		</div>
 	</div>
-	<span id="piece-hover-tooltip">
+	<span id="piece-hover-tooltip" class="p-2 hidden fixed overflow-hidden border border-solid border-black rounded">
 		{#if hoveredPiece}
 			{@const hoveredUnit = hoveredPiece.playerUnit.unit}
 			<div>{hoveredPiece.playerUnit.name} ({hoveredUnit.name})</div>

--- a/client/src/lib/components/sandbox/play/utils.ts
+++ b/client/src/lib/components/sandbox/play/utils.ts
@@ -1,5 +1,6 @@
-export const makePiece = (x: number, y: number, radius: number, fill: string) => {
+export const makePiece = (gamePieceId: number, x: number, y: number, radius: number, fill: string) => {
   const piece = {
+    gamePieceId: gamePieceId,
     x: x,
     y: y,
     radius: radius,
@@ -8,18 +9,73 @@ export const makePiece = (x: number, y: number, radius: number, fill: string) =>
   return piece;
 };
 
-export const drawAllPieces = (canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D, pieces: Array<DrawnPiece>) => {
+export const drawAllPieces = (
+  canvas: HTMLCanvasElement,
+  ctx: CanvasRenderingContext2D,
+  pieces: Array<DrawnPiece>,
+  hoveredPiece?: GamePiece,
+  selectedPiece?: GamePiece
+) => {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   for (let i = 0; i < pieces.length; i++) {
     const piece = pieces[i];
-    drawPiece(ctx, piece);
-    ctx.fillStyle = piece.fill;
+    const isHovered = hoveredPiece?.id === piece.gamePieceId;
+    const isSelected = selectedPiece?.id === piece.gamePieceId;
+    
+    let pieceRenderMode: PieceRenderMode = 'normal';
+    if (isHovered && !selectedPiece) {
+      pieceRenderMode = 'hovered';
+    } else if (isSelected) {
+      pieceRenderMode = 'selected';
+    }
+
+    drawPiece(ctx, piece, pieceRenderMode);
     ctx.fill();
     ctx.stroke();
   }
 };
 
-export const drawPiece = (ctx: CanvasRenderingContext2D, piece: DrawnPiece) => {
+export type PieceRenderMode = 'normal' | 'hovered' | 'selected';
+
+export const drawPiece = (ctx: CanvasRenderingContext2D, piece: DrawnPiece, pieceRenderMode: PieceRenderMode) => {
   ctx.beginPath();
-  ctx.arc(piece.x, piece.y, piece.radius, 0, 2 * Math.PI, false);
+  const radius = ['hovered', 'selected'].includes(pieceRenderMode) ? piece.radius + 2 : piece.radius;
+  ctx.lineWidth = pieceRenderMode === 'selected' ? 2 : 1;
+  ctx.strokeStyle = 'charcoal';
+  ctx.arc(piece.x, piece.y, radius, 0, 2 * Math.PI, false);
+  ctx.fillStyle = piece.fill;
 };
+
+// Given a MouseEvent and an HTMLCanvasElement, determine at what
+// coordinates the MouseEvent occurred on the canvas,
+// rather than at the absolute point on the screen
+export const getMouseCanvasPoint = (e: MouseEvent, canvas: HTMLCanvasElement): Point => {
+  const rect = canvas.getBoundingClientRect();
+  return {
+    x: e.clientX - rect.left,
+    y: e.clientY - rect.top
+  };
+}
+
+export const gamePieceById = (id: number, gamePieces: Array<GamePiece>): GamePiece | undefined => {
+  return gamePieces.find(p => p.id === id);
+}
+
+export const distanceBetweenPoints = (point1: Point, point2: Point) => {
+  const dx = point2.x - point1.x;
+  const dy = point2.y - point1.y;
+  return Math.sqrt((dx * dx) + (dy * dy));
+}
+
+// Get the GamePiece at a particular point on the canvas
+export const pieceAtCanvasPoint = (
+  canvasPoint: Point,
+  drawnPieces: Array<DrawnPiece>,
+  gamePieces: Array<GamePiece>,
+): GamePiece | undefined => {
+  const drawnPiece = drawnPieces.find(drawnPiece => {
+    const piecePos = { x: drawnPiece.x, y: drawnPiece.y };
+    return distanceBetweenPoints(canvasPoint, piecePos) < drawnPiece.radius;
+  });
+  return drawnPiece ? gamePieceById(drawnPiece.gamePieceId, gamePieces) : undefined;
+}

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -11,7 +11,7 @@ type Game = {
   currentPhase?: GamePhase;
   gamePlayers?: Array<GamePlayer>;
   gamePieces: Array<GamePiece>;
-  arena?: {
+  arena: {
     width: number;
     height: number;
   }
@@ -107,6 +107,7 @@ type CreateGamePieceInput = {
 }
 
 type DrawnPiece = {
+  gamePieceId: number;
   x: number;
   y: number;
   radius: number;
@@ -157,4 +158,9 @@ type PublicKeyGroup = {
 type Signature = {
   r: string;
   s: string;
+}
+
+type Point = {
+  x: number;
+  y: number;
 }


### PR DESCRIPTION
## Problem

The game would be much more ergonomic if the user could interact via the mouse instead of entering unit orders via text inputs.

## Solution

Lay some groundwork for handling mouse events. This PR allows the user to hover the mouse over a GamePiece and shows a tooltip with some details about the piece/unit. It also allows the user to click a GamePiece on the board to select it, highlighting the selected piece.

A follow-up PR will allow the user to issue move orders to selected units using the mouse.


https://github.com/trumpet-zk-ignite-1/mina-arena/assets/8811423/cd35c16c-8704-4dd1-b85e-e2a8db35809d

Prime: @45930 