### PR TITLE
Implement dice roll client

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,1 +1,2 @@
 VITE_BACKEND_SERVER_URL=http://localhost:5001
+VITE_DICE_ROLL_SERVICE_URL=http://localhost:5002

--- a/client/src/lib/components/sandbox/play/MainGamePage.svelte
+++ b/client/src/lib/components/sandbox/play/MainGamePage.svelte
@@ -3,8 +3,6 @@
 	import { MinaArenaClient } from '$lib/mina-arena-graphql-client/MinaArenaClient';
 	import { page } from '$app/stores';
 
-	import { smoke } from '$lib/dice-service-client/snarky-js-smoke-test';
-
 	import PhaseInput from './phase-input/PhaseInput.svelte';
 	import Arena from './Arena.svelte';
 	import { truncateMinaPublicKey } from '$lib/utils';
@@ -13,8 +11,6 @@
 	let currentGame: Game;
 	const minaArenaClient = new MinaArenaClient();
 	let loaded = false;
-
-	const smokeCopy = smoke;
 
 	onMount(async () => {
 		currentGame = await minaArenaClient.getGame(gameId);

--- a/client/src/lib/dice-service-client/DiceRollServiceClient.ts
+++ b/client/src/lib/dice-service-client/DiceRollServiceClient.ts
@@ -1,0 +1,22 @@
+// The pub key that Mina Arena server will use to decrypt the message
+// e.g. the address to which to encrypt the message
+const SERVER_PUBLIC_KEY = 'B62qpge4uMq4Vv5Rvc8Gw9qSquUYd6xoW1pz7HQkMSHm6h1o7pvLPAN'
+
+export class DiceRollServiceClient {
+  baseUrl
+
+  constructor() {
+    this.baseUrl = import.meta.env.VITE_DICE_ROLL_SERVICE_URL;
+  }
+
+  async getDiceRolls(n: number, sides: number) {
+    const response = await fetch(
+      `${this.baseUrl}/dice/${SERVER_PUBLIC_KEY}?` + new URLSearchParams({
+        'n': String(n),
+        'sides': String(sides),
+      }).toString()
+    );
+
+    return await response.json();
+  }
+}

--- a/client/src/lib/dice-service-client/snarky-js-smoke-test.ts
+++ b/client/src/lib/dice-service-client/snarky-js-smoke-test.ts
@@ -1,3 +1,0 @@
-import { PrivateKey } from 'snarkyjs';
-
-export const smoke = PrivateKey.random().toBase58();

--- a/client/src/routes/enter/+page.svelte
+++ b/client/src/routes/enter/+page.svelte
@@ -1,3 +1,16 @@
+<script lang="ts">
+	import { DiceRollServiceClient } from '$lib/dice-service-client/DiceRollServiceClient';
+	import { onMount } from 'svelte';
+
+	const diceRollServiceClient = new DiceRollServiceClient();
+
+	onMount(async () => {
+		console.log('getting dice rolls');
+		const resp = await diceRollServiceClient.getDiceRolls(2, 6);
+		console.log(JSON.stringify(resp));
+	});
+</script>
+
 <div class="flex">
 	<div class="mt-6 mb-10 h-fit text-center w-1/2 mx-auto">
 		<h2 class="text-2xl font-semibold">Choose your path</h2>


### PR DESCRIPTION
Prime: @louiswheeleriv 

Adding a dice roll client which calls out to mina-rng.  You should be able to use this with each piece's attack phases.

The way we implemented attacks in the server, I think we actually need to get 1 roll at a time always, not a variable number or rolls based on the unit's number of attacks.  So if there are 3 attacks for a unit, we should call out 3 times to the API.  Maybe we can go into the mina-rng server and make a more effecient response of exactly what we need (an array of individually signed single-rolls, vs a signed message of 3 rolls together).