### PR TITLE
Add loading state after submitting phase orders

### DIFF
--- a/client/src/app.html
+++ b/client/src/app.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width" />
+		<script src="https://kit.fontawesome.com/c63d32caae.js" crossorigin="anonymous"></script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/client/src/lib/components/sandbox/arena/ArenaCanvasMeleePhase.svelte
+++ b/client/src/lib/components/sandbox/arena/ArenaCanvasMeleePhase.svelte
@@ -3,6 +3,7 @@
   import * as Utils from '../play/utils';
   import { MinaArenaClient } from '$lib/mina-arena-graphql-client/MinaArenaClient';
   import HoveredGamePieceTooltipMelee from './HoveredGamePieceTooltipMelee.svelte';
+  import SubmitPhaseButton from './SubmitPhaseButton.svelte';
 
   export let game: Game;
   export let playerColors: Array<string>;
@@ -10,6 +11,7 @@
 
   let canvas: HTMLCanvasElement;
   let ctx: CanvasRenderingContext2D;
+  let isLoading: Boolean = false;
 
   let currentPlayerMinaPubKey: string = game.currentPhase?.gamePlayer.player.minaPublicKey || '';
   let gamePieces: Array<GamePiece> = game.gamePieces;
@@ -205,6 +207,7 @@
     Object.values(orders).flat().forEach((meleeOrder: GamePieceOrder) => {
       if (meleeOrder.meleeAttack) meleeAttackActions.push(meleeOrder.meleeAttack);
     });
+    isLoading = true;
     await minaArenaClient.submitMeleePhase(
       currentPlayerMinaPubKey,
       game.id,
@@ -238,13 +241,7 @@
   </tr>
   <tr>
     <div class="flex">
-      <button
-        id="submit-phase-button"
-        class="mx-auto m-2 p-2 rounded-lg border border-slate-900 bg-gray-200 hover:bg-gray-400"
-        on:click={submitPhase}
-      >
-        Submit Phase
-      </button>
+      <SubmitPhaseButton isLoading={isLoading} submitPhaseCallback={submitPhase} />
       {#if selectedPiece}
         <div></div>
       {/if}

--- a/client/src/lib/components/sandbox/arena/ArenaCanvasMovementPhase.svelte
+++ b/client/src/lib/components/sandbox/arena/ArenaCanvasMovementPhase.svelte
@@ -3,6 +3,7 @@
   import * as Utils from '../play/utils';
   import { MinaArenaClient } from '$lib/mina-arena-graphql-client/MinaArenaClient';
   import HoveredGamePieceTooltipMovement from './HoveredGamePieceTooltipMovement.svelte';
+  import SubmitPhaseButton from './SubmitPhaseButton.svelte';
 
   export let game: Game;
   export let playerColors: Array<string>;
@@ -10,6 +11,7 @@
 
   let canvas: HTMLCanvasElement;
   let ctx: CanvasRenderingContext2D;
+  let isLoading: Boolean = false;
 
   let currentPlayerMinaPubKey: string = game.currentPhase?.gamePlayer.player.minaPublicKey || '';
   let gamePieces: Array<GamePiece> = game.gamePieces;
@@ -199,6 +201,7 @@
     Object.values(orders).flat().forEach((moveOrder: GamePieceOrder) => {
       if (moveOrder.move) moveActions.push(moveOrder.move);
     });
+    isLoading = true;
     await minaArenaClient.submitMovePhase(
       currentPlayerMinaPubKey,
       game.id,
@@ -232,13 +235,7 @@
   </tr>
   <tr>
     <div class="flex">
-      <button
-        id="submit-phase-button"
-        class="mx-auto m-2 p-2 rounded-lg border border-slate-900 bg-gray-200 hover:bg-gray-400"
-        on:click={submitPhase}
-      >
-        Submit Phase
-      </button>
+      <SubmitPhaseButton isLoading={isLoading} submitPhaseCallback={submitPhase} />
       {#if selectedPiece}
         <div></div>
       {/if}

--- a/client/src/lib/components/sandbox/arena/ArenaCanvasShootingPhase.svelte
+++ b/client/src/lib/components/sandbox/arena/ArenaCanvasShootingPhase.svelte
@@ -3,6 +3,7 @@
   import * as Utils from '../play/utils';
   import { MinaArenaClient } from '$lib/mina-arena-graphql-client/MinaArenaClient';
   import HoveredGamePieceTooltipShooting from './HoveredGamePieceTooltipShooting.svelte';
+  import SubmitPhaseButton from './SubmitPhaseButton.svelte';
 
   export let game: Game;
   export let playerColors: Array<string>;
@@ -10,6 +11,7 @@
 
   let canvas: HTMLCanvasElement;
   let ctx: CanvasRenderingContext2D;
+  let isLoading: Boolean = false;
 
   let currentPlayerMinaPubKey: string = game.currentPhase?.gamePlayer.player.minaPublicKey || '';
   let gamePieces: Array<GamePiece> = game.gamePieces;
@@ -211,6 +213,7 @@
     Object.values(orders).flat().forEach((shootOrder: GamePieceOrder) => {
       if (shootOrder.rangedAttack) rangedAttackActions.push(shootOrder.rangedAttack);
     });
+    isLoading = true;
     await minaArenaClient.submitShootingPhase(
       currentPlayerMinaPubKey,
       game.id,
@@ -244,13 +247,7 @@
   </tr>
   <tr>
     <div class="flex">
-      <button
-        id="submit-phase-button"
-        class="mx-auto m-2 p-2 rounded-lg border border-slate-900 bg-gray-200 hover:bg-gray-400"
-        on:click={submitPhase}
-      >
-        Submit Phase
-      </button>
+      <SubmitPhaseButton isLoading={isLoading} submitPhaseCallback={submitPhase} />
       {#if selectedPiece}
         <div></div>
       {/if}

--- a/client/src/lib/components/sandbox/arena/SubmitPhaseButton.svelte
+++ b/client/src/lib/components/sandbox/arena/SubmitPhaseButton.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+
+  export let submitPhaseCallback: () => void;
+  export let isLoading: Boolean;
+
+</script>
+
+{#if isLoading}
+  <button
+    id="submit-phase-button"
+    class="mx-auto m-2 p-2 rounded-lg border border-slate-500 bg-gray-100 text-gray-700"
+    disabled
+  >
+    <i class="fa-solid fa-arrows-rotate fa-spin"></i> Resolving...
+  </button>
+{:else}
+  <button
+    id="submit-phase-button"
+    class="mx-auto m-2 p-2 rounded-lg border border-slate-800 bg-gray-200 hover:bg-gray-400"
+    on:click={submitPhaseCallback}
+  >
+    Submit Phase
+  </button>
+{/if}


### PR DESCRIPTION
## Problem

Currently when you submit your phase orders, which takes about 15 seconds for the movement phase, we do not show any kind of loading state, still allowing the user to click the Submit Phase button during that time.

## Solution

Add a loading state after submitting phase orders.


https://github.com/trumpet-zk-ignite-1/mina-arena/assets/8811423/01dace96-3d79-4047-8779-a797d5857637


