### PR TITLE
Add action log to display actions resolved in previous phase

### DIFF
--- a/client/src/lib/components/sandbox/arena/ArenaActionLog.svelte
+++ b/client/src/lib/components/sandbox/arena/ArenaActionLog.svelte
@@ -1,213 +1,213 @@
 <script lang="ts">
-  import { truncateMinaPublicKey } from '$lib/utils';
+	import { truncateMinaPublicKey } from '$lib/utils';
 
-  import { onMount } from 'svelte';
+	import { onMount } from 'svelte';
 	import { playerColor } from '../play/utils';
 
-  export let game: Game;
-  export let playerPublicKeys: Array<string>;
-  export let playerColors: Array<string>;
+	export let game: Game;
+	export let playerPublicKeys: Array<string>;
+	export let playerColors: Array<string>;
 
-  const textColorByPlayerColor: Record<string, string> = {
-    'pink': '#FF3030',
-    'lightblue': '#5050FF',
-  };
+	const textColorByPlayerColor: Record<string, string> = {
+		'pink': '#FF3030',
+		'lightblue': '#5050FF',
+	};
 
-  const colorByPlayerKey: Record<string, string> = playerPublicKeys.reduce((acc, key) => {
-    const rawColor = playerColor(playerPublicKeys, key, playerColors);
-    acc[key] = textColorByPlayerColor[rawColor] || rawColor;
-    return acc;
-  }, {} as Record<string, string>);
+	const colorByPlayerKey: Record<string, string> = playerPublicKeys.reduce((acc, key) => {
+		const rawColor = playerColor(playerPublicKeys, key, playerColors);
+		acc[key] = textColorByPlayerColor[rawColor] || rawColor;
+		return acc;
+	}, {} as Record<string, string>);
 
-  onMount(() => {
-    const log = document.getElementById('action-log') as HTMLDivElement;
-    const prevPhase = game.previousPhase;
-    if (!log || !prevPhase) return;
+	onMount(() => {
+		const log = document.getElementById('action-log') as HTMLDivElement;
+		const prevPhase = game.previousPhase;
+		if (!log || !prevPhase) return;
 
-    let actionLogText = '';
-    actionLogText += `Previous Phase: ${prevPhase.name}<br/><br/>`;
+		let actionLogText = '';
+		actionLogText += `Previous Phase: ${prevPhase.name}<br/><br/>`;
 
-    if (prevPhase.gamePieceActions.length > 0) {
-      prevPhase.gamePieceActions.forEach(action => {
-        switch(action.actionType) {
-          case 'MOVE':
-            actionLogText += movementActionLogText(action);
-            break;
-          case 'RANGED_ATTACK':
-            actionLogText += rangedAttackActionLogText(action);
-            break;
-          case 'MELEE_ATTACK':
-            actionLogText += meleeAttackActionLogText(action);
-            break;
-        }
-      });
-    } else {
-      actionLogText += 'No actions were made.'
-    }
-    
-    log.innerHTML += actionLogText;
-  });
+		if (prevPhase.gamePieceActions.length > 0) {
+			prevPhase.gamePieceActions.forEach(action => {
+				switch(action.actionType) {
+					case 'MOVE':
+						actionLogText += movementActionLogText(action);
+						break;
+					case 'RANGED_ATTACK':
+						actionLogText += rangedAttackActionLogText(action);
+						break;
+					case 'MELEE_ATTACK':
+						actionLogText += meleeAttackActionLogText(action);
+						break;
+				}
+			});
+		} else {
+			actionLogText += 'No actions were made.'
+		}
+		
+		log.innerHTML += actionLogText;
+	});
 
-  const movementActionLogText = (action: GamePieceAction): string => {
-    let text = '';
-    const playerKey = action.gamePiece.gamePlayer.player.minaPublicKey;
-    const color = colorByPlayerKey[playerKey];
-    const playerUnit = action.gamePiece.playerUnit;
-    text += `<span style="color: ${color};">${playerUnit.name} (${playerUnit.unit.name})</span> moves`;
-    return `${text}<br/>`;
-  }
+	const movementActionLogText = (action: GamePieceAction): string => {
+		let text = '';
+		const playerKey = action.gamePiece.gamePlayer.player.minaPublicKey;
+		const color = colorByPlayerKey[playerKey];
+		const playerUnit = action.gamePiece.playerUnit;
+		text += `<span style="color: ${color};">${playerUnit.name} (${playerUnit.unit.name})</span> moves`;
+		return `${text}<br/>`;
+	}
 
-  const rangedAttackActionLogText = (action: GamePieceAction): string => {
-    let text = '';
-    const attacks = action.actionData.resolvedAttacks;
-    const attackingPiece = action.gamePiece;
-    const targetPiece = action.actionData.targetGamePiece;
-    if (!targetPiece || !attacks) return '';
+	const rangedAttackActionLogText = (action: GamePieceAction): string => {
+		let text = '';
+		const attacks = action.actionData.resolvedAttacks;
+		const attackingPiece = action.gamePiece;
+		const targetPiece = action.actionData.targetGamePiece;
+		if (!targetPiece || !attacks) return '';
 
-    const attackingPlayerUnit = attackingPiece.playerUnit;
-    const targetPlayerUnit = targetPiece.playerUnit;
-    const attackingPlayerKey = attackingPiece.gamePlayer.player.minaPublicKey;
-    const targetPlayerKey = targetPiece.gamePlayer.player.minaPublicKey;
-    const attackingPlayerColor = colorByPlayerKey[attackingPlayerKey] || 'black';
-    const targetPlayerColor = targetPlayerKey ? colorByPlayerKey[targetPlayerKey] || 'black' : 'black';
-    
-    const attackingPieceTitle = `<span style="color: ${attackingPlayerColor}">${attackingPlayerUnit.name} (${attackingPlayerUnit.unit.name})</span>`;
-    const targetPieceTitle = `<span style="color: ${targetPlayerColor}">${targetPlayerUnit.name} (${targetPlayerUnit.unit.name})</span>`;
+		const attackingPlayerUnit = attackingPiece.playerUnit;
+		const targetPlayerUnit = targetPiece.playerUnit;
+		const attackingPlayerKey = attackingPiece.gamePlayer.player.minaPublicKey;
+		const targetPlayerKey = targetPiece.gamePlayer.player.minaPublicKey;
+		const attackingPlayerColor = colorByPlayerKey[attackingPlayerKey] || 'black';
+		const targetPlayerColor = targetPlayerKey ? colorByPlayerKey[targetPlayerKey] || 'black' : 'black';
+		
+		const attackingPieceTitle = `<span style="color: ${attackingPlayerColor}">${attackingPlayerUnit.name} (${attackingPlayerUnit.unit.name})</span>`;
+		const targetPieceTitle = `<span style="color: ${targetPlayerColor}">${targetPlayerUnit.name} (${targetPlayerUnit.unit.name})</span>`;
 
-    text += `${attackingPieceTitle} shoots x${attacks.length} at ${targetPieceTitle}<br/>`;
+		text += `${attackingPieceTitle} shoots x${attacks.length} at ${targetPieceTitle}<br/>`;
 
-    let hitRollsPassed: number[] = [];
-    let hitRollsFailed: number[] = [];
-    let woundRollsPassed: number[] = [];
-    let woundRollsFailed: number[] = [];
-    let saveRollsPassed: number[] = [];
-    let saveRollsFailed: number[] = [];
+		let hitRollsPassed: number[] = [];
+		let hitRollsFailed: number[] = [];
+		let woundRollsPassed: number[] = [];
+		let woundRollsFailed: number[] = [];
+		let saveRollsPassed: number[] = [];
+		let saveRollsFailed: number[] = [];
 
-    attacks.forEach(attack => {
-      if (attack.hitRoll.success) {
-        hitRollsPassed.push(attack.hitRoll.roll);
-      } else {
-        hitRollsFailed.push(attack.hitRoll.roll);
-        return;
-      }
-      if (attack.woundRoll.success) {
-        woundRollsPassed.push(attack.woundRoll.roll);
-      } else {
-        woundRollsFailed.push(attack.woundRoll.roll);
-        return;
-      }
-      if (attack.saveRoll.success) {
-        saveRollsPassed.push(attack.saveRoll.roll);
-      } else {
-        saveRollsFailed.push(attack.saveRoll.roll);
-      }
-    });
+		attacks.forEach(attack => {
+			if (attack.hitRoll.success) {
+				hitRollsPassed.push(attack.hitRoll.roll);
+			} else {
+				hitRollsFailed.push(attack.hitRoll.roll);
+				return;
+			}
+			if (attack.woundRoll.success) {
+				woundRollsPassed.push(attack.woundRoll.roll);
+			} else {
+				woundRollsFailed.push(attack.woundRoll.roll);
+				return;
+			}
+			if (attack.saveRoll.success) {
+				saveRollsPassed.push(attack.saveRoll.roll);
+			} else {
+				saveRollsFailed.push(attack.saveRoll.roll);
+			}
+		});
 
-    text += `${attacks[0].hitRoll.rollNeeded}+ to hit: `;
-    text += `<span style="color: green;">${hitRollsPassed.join(' ')}</span> `;
-    text += `<span style="color: red;">${hitRollsFailed.join(' ')}</span><br/>`;
+		text += `${attacks[0].hitRoll.rollNeeded}+ to hit: `;
+		text += `<span style="color: green;">${hitRollsPassed.join(' ')}</span> `;
+		text += `<span style="color: red;">${hitRollsFailed.join(' ')}</span><br/>`;
 
-    if (hitRollsPassed.length > 0) {
-      text += `${attacks[0].woundRoll.rollNeeded}+ to wound: `;
-      text += `<span style="color: green;">${woundRollsPassed.join(' ')}</span> `;
-      text += `<span style="color: red;">${woundRollsFailed.join(' ')}</span><br/>`;
+		if (hitRollsPassed.length > 0) {
+			text += `${attacks[0].woundRoll.rollNeeded}+ to wound: `;
+			text += `<span style="color: green;">${woundRollsPassed.join(' ')}</span> `;
+			text += `<span style="color: red;">${woundRollsFailed.join(' ')}</span><br/>`;
 
-      if (woundRollsPassed.length > 0) {
-        text += `${attacks[0].saveRoll.rollNeeded}+ to save: `;
-        text += `<span style="color: green;">${saveRollsPassed.join(' ')}</span> `;
-        text += `<span style="color: red;">${saveRollsFailed.join(' ')}</span><br/>`;
-      }
-    }
+			if (woundRollsPassed.length > 0) {
+				text += `${attacks[0].saveRoll.rollNeeded}+ to save: `;
+				text += `<span style="color: green;">${saveRollsPassed.join(' ')}</span> `;
+				text += `<span style="color: red;">${saveRollsFailed.join(' ')}</span><br/>`;
+			}
+		}
 
-    const totalDmg = action.actionData.totalDamageDealt;
-    text += `Damage: ${totalDmg} (avg. ${action.actionData.totalDamageAverage?.toFixed(1)})<br/>`;
+		const totalDmg = action.actionData.totalDamageDealt;
+		text += `Damage: ${totalDmg} (avg. ${action.actionData.totalDamageAverage?.toFixed(1)})<br/>`;
 
-    if (totalDmg && totalDmg > 0) {
-      if (targetPiece.health > 0) {
-        text += `${targetPieceTitle} is down to ${targetPiece.health}/${targetPlayerUnit.unit.maxHealth} HP`;
-      } else {
-        text += `${targetPieceTitle} was destroyed!`;
-      }
-    }
+		if (totalDmg && totalDmg > 0) {
+			if (targetPiece.health > 0) {
+				text += `${targetPieceTitle} is down to ${targetPiece.health}/${targetPlayerUnit.unit.maxHealth} HP`;
+			} else {
+				text += `${targetPieceTitle} was destroyed!`;
+			}
+		}
 
-    return `${text}<br/><br/>`;
-  }
+		return `${text}<br/><br/>`;
+	}
 
-  const meleeAttackActionLogText = (action: GamePieceAction): string => {
-    let text = '';
-    const attacks = action.actionData.resolvedAttacks;
-    const attackingPiece = action.gamePiece;
-    const targetPiece = action.actionData.targetGamePiece;
-    if (!targetPiece || !attacks) return '';
+	const meleeAttackActionLogText = (action: GamePieceAction): string => {
+		let text = '';
+		const attacks = action.actionData.resolvedAttacks;
+		const attackingPiece = action.gamePiece;
+		const targetPiece = action.actionData.targetGamePiece;
+		if (!targetPiece || !attacks) return '';
 
-    const attackingPlayerUnit = attackingPiece.playerUnit;
-    const targetPlayerUnit = targetPiece.playerUnit;
-    const attackingPlayerKey = attackingPiece.gamePlayer.player.minaPublicKey;
-    const targetPlayerKey = targetPiece.gamePlayer.player.minaPublicKey;
-    const attackingPlayerColor = colorByPlayerKey[attackingPlayerKey] || 'black';
-    const targetPlayerColor = targetPlayerKey ? colorByPlayerKey[targetPlayerKey] || 'black' : 'black';
-    
-    const attackingPieceTitle = `<span style="color: ${attackingPlayerColor}">${attackingPlayerUnit.name} (${attackingPlayerUnit.unit.name})</span>`;
-    const targetPieceTitle = `<span style="color: ${targetPlayerColor}">${targetPlayerUnit.name} (${targetPlayerUnit.unit.name})</span>`;
+		const attackingPlayerUnit = attackingPiece.playerUnit;
+		const targetPlayerUnit = targetPiece.playerUnit;
+		const attackingPlayerKey = attackingPiece.gamePlayer.player.minaPublicKey;
+		const targetPlayerKey = targetPiece.gamePlayer.player.minaPublicKey;
+		const attackingPlayerColor = colorByPlayerKey[attackingPlayerKey] || 'black';
+		const targetPlayerColor = targetPlayerKey ? colorByPlayerKey[targetPlayerKey] || 'black' : 'black';
+		
+		const attackingPieceTitle = `<span style="color: ${attackingPlayerColor}">${attackingPlayerUnit.name} (${attackingPlayerUnit.unit.name})</span>`;
+		const targetPieceTitle = `<span style="color: ${targetPlayerColor}">${targetPlayerUnit.name} (${targetPlayerUnit.unit.name})</span>`;
 
-    text += `${attackingPieceTitle} strikes x${attacks.length} at ${targetPieceTitle}<br/>`;
+		text += `${attackingPieceTitle} strikes x${attacks.length} at ${targetPieceTitle}<br/>`;
 
-    let hitRollsPassed: number[] = [];
-    let hitRollsFailed: number[] = [];
-    let woundRollsPassed: number[] = [];
-    let woundRollsFailed: number[] = [];
-    let saveRollsPassed: number[] = [];
-    let saveRollsFailed: number[] = [];
+		let hitRollsPassed: number[] = [];
+		let hitRollsFailed: number[] = [];
+		let woundRollsPassed: number[] = [];
+		let woundRollsFailed: number[] = [];
+		let saveRollsPassed: number[] = [];
+		let saveRollsFailed: number[] = [];
 
-    attacks.forEach(attack => {
-      if (attack.hitRoll.success) {
-        hitRollsPassed.push(attack.hitRoll.roll);
-      } else {
-        hitRollsFailed.push(attack.hitRoll.roll);
-        return;
-      }
-      if (attack.woundRoll.success) {
-        woundRollsPassed.push(attack.woundRoll.roll);
-      } else {
-        woundRollsFailed.push(attack.woundRoll.roll);
-        return;
-      }
-      if (attack.saveRoll.success) {
-        saveRollsPassed.push(attack.saveRoll.roll);
-      } else {
-        saveRollsFailed.push(attack.saveRoll.roll);
-      }
-    });
+		attacks.forEach(attack => {
+			if (attack.hitRoll.success) {
+				hitRollsPassed.push(attack.hitRoll.roll);
+			} else {
+				hitRollsFailed.push(attack.hitRoll.roll);
+				return;
+			}
+			if (attack.woundRoll.success) {
+				woundRollsPassed.push(attack.woundRoll.roll);
+			} else {
+				woundRollsFailed.push(attack.woundRoll.roll);
+				return;
+			}
+			if (attack.saveRoll.success) {
+				saveRollsPassed.push(attack.saveRoll.roll);
+			} else {
+				saveRollsFailed.push(attack.saveRoll.roll);
+			}
+		});
 
-    text += `${attacks[0].hitRoll.rollNeeded}+ to hit: `;
-    text += `<span style="color: green;">${hitRollsPassed.join(' ')}</span> `;
-    text += `<span style="color: red;">${hitRollsFailed.join(' ')}</span><br/>`;
+		text += `${attacks[0].hitRoll.rollNeeded}+ to hit: `;
+		text += `<span style="color: green;">${hitRollsPassed.join(' ')}</span> `;
+		text += `<span style="color: red;">${hitRollsFailed.join(' ')}</span><br/>`;
 
-    if (hitRollsPassed.length > 0) {
-      text += `${attacks[0].woundRoll.rollNeeded}+ to wound: `;
-      text += `<span style="color: green;">${woundRollsPassed.join(' ')}</span> `;
-      text += `<span style="color: red;">${woundRollsFailed.join(' ')}</span><br/>`;
+		if (hitRollsPassed.length > 0) {
+			text += `${attacks[0].woundRoll.rollNeeded}+ to wound: `;
+			text += `<span style="color: green;">${woundRollsPassed.join(' ')}</span> `;
+			text += `<span style="color: red;">${woundRollsFailed.join(' ')}</span><br/>`;
 
-      if (woundRollsPassed.length > 0) {
-        text += `${attacks[0].saveRoll.rollNeeded}+ to save: `;
-        text += `<span style="color: green;">${saveRollsPassed.join(' ')}</span> `;
-        text += `<span style="color: red;">${saveRollsFailed.join(' ')}</span><br/>`;
-      }
-    }
+			if (woundRollsPassed.length > 0) {
+				text += `${attacks[0].saveRoll.rollNeeded}+ to save: `;
+				text += `<span style="color: green;">${saveRollsPassed.join(' ')}</span> `;
+				text += `<span style="color: red;">${saveRollsFailed.join(' ')}</span><br/>`;
+			}
+		}
 
-    const totalDmg = action.actionData.totalDamageDealt;
-    text += `Damage: ${totalDmg} (avg. ${action.actionData.totalDamageAverage?.toFixed(1)})`;
+		const totalDmg = action.actionData.totalDamageDealt;
+		text += `Damage: ${totalDmg} (avg. ${action.actionData.totalDamageAverage?.toFixed(1)})`;
 
-    if (totalDmg && totalDmg > 0) {
-      if (targetPiece.health > 0) {
-        text += `<br/>${targetPieceTitle} is down to ${targetPiece.health}/${targetPlayerUnit.unit.maxHealth} HP`;
-      } else {
-        text += `<br/>${targetPieceTitle} was destroyed!`;
-      }
-    }
+		if (totalDmg && totalDmg > 0) {
+			if (targetPiece.health > 0) {
+				text += `<br/>${targetPieceTitle} is down to ${targetPiece.health}/${targetPlayerUnit.unit.maxHealth} HP`;
+			} else {
+				text += `<br/>${targetPieceTitle} was destroyed!`;
+			}
+		}
 
-    return `${text}<br/><br/>`;
-  }
+		return `${text}<br/><br/>`;
+	}
 
 </script>
 

--- a/client/src/lib/components/sandbox/arena/ArenaActionLog.svelte
+++ b/client/src/lib/components/sandbox/arena/ArenaActionLog.svelte
@@ -211,5 +211,5 @@
 
 </script>
 
-<div id="action-log" contenteditable="true" class="h-96 border border-slate-400 mx-auto p-2 overflow-y-auto">
+<div id="action-log" class="h-96 border border-slate-400 mx-auto p-2 overflow-y-auto">
 </div>

--- a/client/src/lib/components/sandbox/arena/ArenaActionLog.svelte
+++ b/client/src/lib/components/sandbox/arena/ArenaActionLog.svelte
@@ -1,0 +1,215 @@
+<script lang="ts">
+  import { truncateMinaPublicKey } from '$lib/utils';
+
+  import { onMount } from 'svelte';
+	import { playerColor } from '../play/utils';
+
+  export let game: Game;
+  export let playerPublicKeys: Array<string>;
+  export let playerColors: Array<string>;
+
+  const textColorByPlayerColor: Record<string, string> = {
+    'pink': '#FF3030',
+    'lightblue': '#5050FF',
+  };
+
+  const colorByPlayerKey: Record<string, string> = playerPublicKeys.reduce((acc, key) => {
+    const rawColor = playerColor(playerPublicKeys, key, playerColors);
+    acc[key] = textColorByPlayerColor[rawColor] || rawColor;
+    return acc;
+  }, {} as Record<string, string>);
+
+  onMount(() => {
+    const log = document.getElementById('action-log') as HTMLDivElement;
+    const prevPhase = game.previousPhase;
+    if (!log || !prevPhase) return;
+
+    let actionLogText = '';
+    actionLogText += `Previous Phase: ${prevPhase.name}<br/><br/>`;
+
+    if (prevPhase.gamePieceActions.length > 0) {
+      prevPhase.gamePieceActions.forEach(action => {
+        switch(action.actionType) {
+          case 'MOVE':
+            actionLogText += movementActionLogText(action);
+            break;
+          case 'RANGED_ATTACK':
+            actionLogText += rangedAttackActionLogText(action);
+            break;
+          case 'MELEE_ATTACK':
+            actionLogText += meleeAttackActionLogText(action);
+            break;
+        }
+      });
+    } else {
+      actionLogText += 'No actions were made.'
+    }
+    
+    log.innerHTML += actionLogText;
+  });
+
+  const movementActionLogText = (action: GamePieceAction): string => {
+    let text = '';
+    const playerKey = action.gamePiece.gamePlayer.player.minaPublicKey;
+    const color = colorByPlayerKey[playerKey];
+    const playerUnit = action.gamePiece.playerUnit;
+    text += `<span style="color: ${color};">${playerUnit.name} (${playerUnit.unit.name})</span> moves`;
+    return `${text}<br/>`;
+  }
+
+  const rangedAttackActionLogText = (action: GamePieceAction): string => {
+    let text = '';
+    const attacks = action.actionData.resolvedAttacks;
+    const attackingPiece = action.gamePiece;
+    const targetPiece = action.actionData.targetGamePiece;
+    if (!targetPiece || !attacks) return '';
+
+    const attackingPlayerUnit = attackingPiece.playerUnit;
+    const targetPlayerUnit = targetPiece.playerUnit;
+    const attackingPlayerKey = attackingPiece.gamePlayer.player.minaPublicKey;
+    const targetPlayerKey = targetPiece.gamePlayer.player.minaPublicKey;
+    const attackingPlayerColor = colorByPlayerKey[attackingPlayerKey] || 'black';
+    const targetPlayerColor = targetPlayerKey ? colorByPlayerKey[targetPlayerKey] || 'black' : 'black';
+    
+    const attackingPieceTitle = `<span style="color: ${attackingPlayerColor}">${attackingPlayerUnit.name} (${attackingPlayerUnit.unit.name})</span>`;
+    const targetPieceTitle = `<span style="color: ${targetPlayerColor}">${targetPlayerUnit.name} (${targetPlayerUnit.unit.name})</span>`;
+
+    text += `${attackingPieceTitle} shoots x${attacks.length} at ${targetPieceTitle}<br/>`;
+
+    let hitRollsPassed: number[] = [];
+    let hitRollsFailed: number[] = [];
+    let woundRollsPassed: number[] = [];
+    let woundRollsFailed: number[] = [];
+    let saveRollsPassed: number[] = [];
+    let saveRollsFailed: number[] = [];
+
+    attacks.forEach(attack => {
+      if (attack.hitRoll.success) {
+        hitRollsPassed.push(attack.hitRoll.roll);
+      } else {
+        hitRollsFailed.push(attack.hitRoll.roll);
+        return;
+      }
+      if (attack.woundRoll.success) {
+        woundRollsPassed.push(attack.woundRoll.roll);
+      } else {
+        woundRollsFailed.push(attack.woundRoll.roll);
+        return;
+      }
+      if (attack.saveRoll.success) {
+        saveRollsPassed.push(attack.saveRoll.roll);
+      } else {
+        saveRollsFailed.push(attack.saveRoll.roll);
+      }
+    });
+
+    text += `${attacks[0].hitRoll.rollNeeded}+ to hit: `;
+    text += `<span style="color: green;">${hitRollsPassed.join(' ')}</span> `;
+    text += `<span style="color: red;">${hitRollsFailed.join(' ')}</span><br/>`;
+
+    if (hitRollsPassed.length > 0) {
+      text += `${attacks[0].woundRoll.rollNeeded}+ to wound: `;
+      text += `<span style="color: green;">${woundRollsPassed.join(' ')}</span> `;
+      text += `<span style="color: red;">${woundRollsFailed.join(' ')}</span><br/>`;
+
+      if (woundRollsPassed.length > 0) {
+        text += `${attacks[0].saveRoll.rollNeeded}+ to save: `;
+        text += `<span style="color: green;">${saveRollsPassed.join(' ')}</span> `;
+        text += `<span style="color: red;">${saveRollsFailed.join(' ')}</span><br/>`;
+      }
+    }
+
+    const totalDmg = action.actionData.totalDamageDealt;
+    text += `Damage: ${totalDmg} (avg. ${action.actionData.totalDamageAverage?.toFixed(1)})<br/>`;
+
+    if (totalDmg && totalDmg > 0) {
+      if (targetPiece.health > 0) {
+        text += `${targetPieceTitle} is down to ${targetPiece.health}/${targetPlayerUnit.unit.maxHealth} HP`;
+      } else {
+        text += `${targetPieceTitle} was destroyed!`;
+      }
+    }
+
+    return `${text}<br/><br/>`;
+  }
+
+  const meleeAttackActionLogText = (action: GamePieceAction): string => {
+    let text = '';
+    const attacks = action.actionData.resolvedAttacks;
+    const attackingPiece = action.gamePiece;
+    const targetPiece = action.actionData.targetGamePiece;
+    if (!targetPiece || !attacks) return '';
+
+    const attackingPlayerUnit = attackingPiece.playerUnit;
+    const targetPlayerUnit = targetPiece.playerUnit;
+    const attackingPlayerKey = attackingPiece.gamePlayer.player.minaPublicKey;
+    const targetPlayerKey = targetPiece.gamePlayer.player.minaPublicKey;
+    const attackingPlayerColor = colorByPlayerKey[attackingPlayerKey] || 'black';
+    const targetPlayerColor = targetPlayerKey ? colorByPlayerKey[targetPlayerKey] || 'black' : 'black';
+    
+    const attackingPieceTitle = `<span style="color: ${attackingPlayerColor}">${attackingPlayerUnit.name} (${attackingPlayerUnit.unit.name})</span>`;
+    const targetPieceTitle = `<span style="color: ${targetPlayerColor}">${targetPlayerUnit.name} (${targetPlayerUnit.unit.name})</span>`;
+
+    text += `${attackingPieceTitle} strikes x${attacks.length} at ${targetPieceTitle}<br/>`;
+
+    let hitRollsPassed: number[] = [];
+    let hitRollsFailed: number[] = [];
+    let woundRollsPassed: number[] = [];
+    let woundRollsFailed: number[] = [];
+    let saveRollsPassed: number[] = [];
+    let saveRollsFailed: number[] = [];
+
+    attacks.forEach(attack => {
+      if (attack.hitRoll.success) {
+        hitRollsPassed.push(attack.hitRoll.roll);
+      } else {
+        hitRollsFailed.push(attack.hitRoll.roll);
+        return;
+      }
+      if (attack.woundRoll.success) {
+        woundRollsPassed.push(attack.woundRoll.roll);
+      } else {
+        woundRollsFailed.push(attack.woundRoll.roll);
+        return;
+      }
+      if (attack.saveRoll.success) {
+        saveRollsPassed.push(attack.saveRoll.roll);
+      } else {
+        saveRollsFailed.push(attack.saveRoll.roll);
+      }
+    });
+
+    text += `${attacks[0].hitRoll.rollNeeded}+ to hit: `;
+    text += `<span style="color: green;">${hitRollsPassed.join(' ')}</span> `;
+    text += `<span style="color: red;">${hitRollsFailed.join(' ')}</span><br/>`;
+
+    if (hitRollsPassed.length > 0) {
+      text += `${attacks[0].woundRoll.rollNeeded}+ to wound: `;
+      text += `<span style="color: green;">${woundRollsPassed.join(' ')}</span> `;
+      text += `<span style="color: red;">${woundRollsFailed.join(' ')}</span><br/>`;
+
+      if (woundRollsPassed.length > 0) {
+        text += `${attacks[0].saveRoll.rollNeeded}+ to save: `;
+        text += `<span style="color: green;">${saveRollsPassed.join(' ')}</span> `;
+        text += `<span style="color: red;">${saveRollsFailed.join(' ')}</span><br/>`;
+      }
+    }
+
+    const totalDmg = action.actionData.totalDamageDealt;
+    text += `Damage: ${totalDmg} (avg. ${action.actionData.totalDamageAverage?.toFixed(1)})`;
+
+    if (totalDmg && totalDmg > 0) {
+      if (targetPiece.health > 0) {
+        text += `<br/>${targetPieceTitle} is down to ${targetPiece.health}/${targetPlayerUnit.unit.maxHealth} HP`;
+      } else {
+        text += `<br/>${targetPieceTitle} was destroyed!`;
+      }
+    }
+
+    return `${text}<br/><br/>`;
+  }
+
+</script>
+
+<div id="action-log" contenteditable="true" class="h-96 border border-slate-400 mx-auto p-2 overflow-y-auto">
+</div>

--- a/client/src/lib/components/sandbox/play/Arena.svelte
+++ b/client/src/lib/components/sandbox/play/Arena.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import ArenaCanvas from '../arena/ArenaCanvas.svelte';
   import ArenaLegend from '../arena/ArenaLegend.svelte';
+  import ArenaActionLog from '../arena/ArenaActionLog.svelte';
 
   export let game: Game;
 
@@ -19,8 +20,19 @@
     playerColors={legendConfig.colors}
     rerender={rerender}
   />
-  <ArenaLegend
-    playerPublicKeys={playerPublicKeys}
-    playerColors={legendConfig.colors}
-  />
+  <table>
+    <tr>
+      <ArenaLegend
+        playerPublicKeys={playerPublicKeys}
+        playerColors={legendConfig.colors}
+      />
+    </tr>
+    <tr>
+      <ArenaActionLog
+        game={game}
+        playerPublicKeys={playerPublicKeys}
+        playerColors={legendConfig.colors}
+      />
+    </tr>
+  </table>
 </div>

--- a/client/src/lib/components/sandbox/play/MainGamePage.svelte
+++ b/client/src/lib/components/sandbox/play/MainGamePage.svelte
@@ -32,6 +32,7 @@
     {#key currentGame}
       {#if currentGame.status === 'IN_PROGRESS'}
         <div>It's your turn: {truncateMinaPublicKey(currentPlayer())}</div>
+				<div>Turn {currentGame.currentPhase?.turnNumber}</div>
         <div>Phase: {currentGame.currentPhase?.name}</div>
       {:else if currentGame.status === 'COMPLETED'}
         <div><b>GAME OVER!</b> Winner: {currentGame.winningGamePlayer?.player.minaPublicKey}</div>

--- a/client/src/lib/components/sandbox/play/MainGamePage.svelte
+++ b/client/src/lib/components/sandbox/play/MainGamePage.svelte
@@ -32,7 +32,7 @@
     {#key currentGame}
       {#if currentGame.status === 'IN_PROGRESS'}
         <div>It's your turn: {truncateMinaPublicKey(currentPlayer())}</div>
-				<div>Turn {currentGame.currentPhase?.turnNumber}</div>
+        <div>Turn {currentGame.currentPhase?.turnNumber}</div>
         <div>Phase: {currentGame.currentPhase?.name}</div>
       {:else if currentGame.status === 'COMPLETED'}
         <div><b>GAME OVER!</b> Winner: {currentGame.winningGamePlayer?.player.minaPublicKey}</div>

--- a/client/src/lib/mina-arena-graphql-client/queries/get-game-status.ts
+++ b/client/src/lib/mina-arena-graphql-client/queries/get-game-status.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client/core/index.js"
 
 export const GetGameStatusQuery = gql`
-  query GetGame($gameId: ID!) {
+  query GetGame($gameId: Int!) {
     game(id: $gameId) {
       id
       status

--- a/client/src/lib/mina-arena-graphql-client/queries/get-game.ts
+++ b/client/src/lib/mina-arena-graphql-client/queries/get-game.ts
@@ -3,13 +3,14 @@ import { UnitFullFragment } from "../fragments";
 
 export const GetGameQuery = gql`
   ${UnitFullFragment}
-  query GetGame($gameId: ID!) {
+  query GetGame($gameId: Int!) {
     game(id: $gameId) {
       id
       status
       turnNumber
       currentPhase {
         id
+        turnNumber
         name
         gamePlayer {
           player {
@@ -57,6 +58,91 @@ export const GetGameQuery = gql`
       arena {
         width
         height
+      }
+      previousPhase {
+        name
+        gamePlayer {
+          player {
+            minaPublicKey
+          }
+        }
+        gamePieceActions {
+          gamePiece {
+            id
+            playerUnit {
+              name
+              unit {
+                name
+              }
+            }
+            gamePlayer {
+              player {
+                minaPublicKey
+              }
+            }
+          }
+          actionType
+          actionData {
+            ... on GamePieceMoveAction {
+              moveFrom { x, y }
+              moveTo { x, y }
+            }
+            ... on GamePieceRangedAttackAction {
+              resolvedAttacks {
+                hitRoll { roll, rollNeeded, success }
+                woundRoll { roll, rollNeeded, success }
+                saveRoll { roll, rollNeeded, success }
+                damageDealt
+                averageDamage
+              }
+              targetGamePiece {
+                id
+                health
+                playerUnit {
+                  name
+                  unit {
+                    name
+                    maxHealth
+                  }
+                }
+                gamePlayer {
+                  player {
+                    minaPublicKey
+                  }
+                }
+              }
+              totalDamageDealt
+              totalDamageAverage
+            }
+            ... on GamePieceMeleeAttackAction {
+              resolvedAttacks {
+                hitRoll { roll, rollNeeded, success }
+                woundRoll { roll, rollNeeded, success }
+                saveRoll { roll, rollNeeded, success }
+                damageDealt
+                averageDamage
+              }
+              targetGamePiece {
+                id
+                health
+                playerUnit {
+                  name
+                  unit {
+                    name
+                    maxHealth
+                  }
+                }
+                gamePlayer {
+                  player {
+                    minaPublicKey
+                  }
+                }
+              }
+              totalDamageDealt
+              totalDamageAverage
+            }
+          }
+        }
       }
     }
   }

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -9,6 +9,7 @@ type Game = {
   status?: 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELED';
   turnNumber?: number;
   currentPhase?: GamePhase;
+  previousPhase?: GamePhase;
   gamePlayers?: Array<GamePlayer>;
   winningGamePlayer?: GamePlayer;
   gamePieces: Array<GamePiece>;
@@ -31,19 +32,50 @@ type GamePiece = {
 
 type GamePhase = {
   id: number;
+  turnNumber: number;
   name: string;
   gamePlayer: {
     player: {
       minaPublicKey: string;
     }
   }
-  gamePieceActions: {
-    id: number;
-    gamePiece: {
-      id: number;
+  gamePieceActions: GamePieceAction[];
+}
+
+type GamePieceAction = {
+  id: number;
+  gamePiece: GamePiece;
+  actionType: GamePieceActionType;
+  actionData: {
+    moveFrom?: {
+      x: number;
+      y: number;
     }
-    actionType: 'MOVEMENT'
+    moveTo?: {
+      x: number;
+      y: number;
+    }
+    targetGamePiece?: GamePiece;
+    resolvedAttacks?: ResolvedAttack[];
+    totalDamageDealt?: number;
+    totalDamageAverage?: number;
   }
+}
+
+type GamePieceActionType = 'MOVE' | 'RANGED_ATTACK' | 'MELEE_ATTACK';
+
+type ResolvedAttack = {
+  hitRoll: RollResult;
+  woundRoll: RollResult;
+  saveRoll: RollResult;
+  damageDealt: number;
+  averageDamage: number;
+}
+
+type RollResult = {
+  roll: number;
+  rollNeeded: number;
+  success: Boolean;
 }
 
 type GamePlayer = {


### PR DESCRIPTION
Prime @45930 

## Problem

Currently the user doesn't have a great view into what happened in the previous phase which was just resolved. Did I do damage? What even happened?

## Solution

Add a simple action log on the side, somewhat like a chat box, which displays the actions which happened in the previous phase.

https://github.com/trumpet-zk-ignite-1/mina-arena/assets/8811423/a430f390-564d-4c1c-ac22-ece4b91b1577

## Notes

In order to get the server running to test this locally, I had to checkout an older commit on the server repo and fiddle with a couple things like the melee range having increased and the IDs being `Int!` type now. We should be prepared to iron out any bugs caused by inconsistencies between the server and client once we get the server's snarky issue resolved.
