### PR TITLE
Adjust appearance of attack arrows

### DIFF
--- a/client/src/lib/components/sandbox/arena/ArenaCanvasMeleePhase.svelte
+++ b/client/src/lib/components/sandbox/arena/ArenaCanvasMeleePhase.svelte
@@ -148,8 +148,23 @@
   const draftMeleeOrder = (targetPiece: GamePiece) => {
     if (!selectedPiece) return;
 
+    // Validate that the selected piece is owned by the
+    // active player, and the target piece is not.
     const selectedPiecePlayerKey = selectedPiece.gamePlayer.player.minaPublicKey;
-    if (selectedPiecePlayerKey !== currentPlayerMinaPubKey) return;
+    const targetPiecePlayerKey = targetPiece.gamePlayer.player.minaPublicKey;
+    if (
+      selectedPiecePlayerKey !== currentPlayerMinaPubKey ||
+      targetPiecePlayerKey === currentPlayerMinaPubKey
+    ) {
+      return;
+    }
+
+    // Validate that the selected piece is in range
+    const attackDistance = Utils.distanceBetweenPoints(
+      selectedPiece.coordinates,
+      targetPiece.coordinates
+    );
+    if (attackDistance > Utils.MELEE_ATTACK_RANGE) return;
 
     const placeholderDiceRoll = {
       publicKey: {

--- a/client/src/lib/components/sandbox/arena/ArenaCanvasMeleePhase.svelte
+++ b/client/src/lib/components/sandbox/arena/ArenaCanvasMeleePhase.svelte
@@ -56,8 +56,8 @@
   afterUpdate(() => {
     Utils.clearCanvas(ctx);
     Utils.drawArenaBackground(ctx);
-    drawMeleePhase(canvas, orders, selectedPiece);
     drawPieces();
+    drawMeleePhase(canvas, orders, selectedPiece);
   });
 
   const drawPieces = () => {
@@ -113,7 +113,7 @@
       attackingPiece.coordinates,
       targetPiece.coordinates,
       MELEE_ARROW_COLOR,
-      Utils.PIECE_RADIUS + 6,
+      Utils.PIECE_RADIUS - 4,
     );
   }
 


### PR DESCRIPTION
## Problem

- The drawn attack arrows are currently drawn from _under_ the center of the attacking piece to the very edge of the target piece. If the attacking and target pieces are very close to each other, this can result in the attack arrow being very hard to see or straight up not visible if the pieces are touching/overlapping.
- There's a bug which allows you to draft a ranged attack order from a unit which has no ranged attack, like a Swordsman
- There's a bug which allows you to draft a ranged attack targeting a friendly unit

## Solution

- Draw attack arrows from the center of the attacking piece to slightly before the center of the target piece, _with the arrow drawn on top of the pieces_. This ensures that even if the pieces are very close, you can see the arrow.
- Fix the bugs allowing drafting of illegal attacks (attacking friendly unit, attacking out of range)

Screenshot showing shooting phase arrows drawn on top of pieces for better visibility
![Screen Shot 2023-07-07 at 5 34 48 PM](https://github.com/trumpet-zk-ignite-1/mina-arena/assets/8811423/38c2b398-f8f9-4c7d-8056-f7f6085ca261)

Screenshot showing melee phase arrows drawn on top of pieces for better visibility
![Screen Shot 2023-07-07 at 4 55 32 PM](https://github.com/trumpet-zk-ignite-1/mina-arena/assets/8811423/782e85fe-e0d9-448e-8ba7-1f6ffc2d42a4)

