### PR TITLE
UI changes, adding user modal

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -26,12 +26,6 @@
 }
 
 @layer utilities {
-  ._button {
-    border: 1px solid rgb(46, 52, 58);
-    border-radius: 6px;
-    padding: 0.5rem;
-  }
-
   ._input {
     border: 1px solid lightgrey;
     border-radius: 1px;

--- a/client/src/lib/components/Header.svelte
+++ b/client/src/lib/components/Header.svelte
@@ -1,15 +1,18 @@
+<script lang="ts">
+	import NavItem from './utils/NavItem.svelte';
+
+	export let openUserModal: () => void;
+</script>
+
 <header>
-	<nav class="border-gray-200 px-4 lg:px-6 py-2.5 bg-light">
-		<div class="flex flex-wrap justify-between items-center mx-auto w-1/2">
-			<span class="self-center text-xl font-semibold whitespace-nowrap text-dark"
-				><a href="/how-to-play">How To Play</a></span
-			>
-			<span class="self-center text-xl font-semibold whitespace-nowrap text-dark">
-				<a href="/barracks">Barracks</a></span
-			>
-			<span class="self-center text-xl font-semibold whitespace-nowrap text-dark">
-				<a href="/enter">Play</a></span
-			>
+	<nav class="flex border-gray-200 px-4 lg:px-6 py-2.5 bg-light">
+		<div class="flex flex-wrap items-center ml-10 w-full">
+			<NavItem href="/how-to-play">How To Play</NavItem>
+			<NavItem href="/barracks">Barracks</NavItem>
+			<NavItem href="/play">Play</NavItem>
+		</div>
+		<div class="mr-10 cursor-pointer" on:click={openUserModal} on:keydown={openUserModal}>
+			<NavItem><i class="_nav_item fa-solid fa-user" /></NavItem>
 		</div>
 	</nav>
 </header>

--- a/client/src/lib/components/modals/DraftUnitModal.svelte
+++ b/client/src/lib/components/modals/DraftUnitModal.svelte
@@ -31,7 +31,7 @@
 				<label>Name:</label>
 				<input class="_input" type="text" bind:value={drafteeName} />
 			</div>
-			<button class="_button" on:click={draft}>Draft Unit</button>
+			<button class="rounded p-2" on:click={draft}>Draft Unit</button>
 		</div>
 	</div>
 {/if}

--- a/client/src/lib/components/modals/UserModal.svelte
+++ b/client/src/lib/components/modals/UserModal.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { closeModal } from 'svelte-modals';
+
+	// provided by Modals
+	export let isOpen: boolean;
+</script>
+
+{#if isOpen}
+	<div class="modal">
+		<div
+			class="w-[500px] h-[400px] rounded-md p-4 bg-white flex flex-col justify-center pointer-events-auto"
+		>
+			<div>Hello!</div>
+		</div>
+	</div>
+{/if}

--- a/client/src/lib/components/sandbox/squad-selection/MainDraftPage.svelte
+++ b/client/src/lib/components/sandbox/squad-selection/MainDraftPage.svelte
@@ -56,7 +56,7 @@
 			<h3 class="text-xl">Select your squad</h3>
 			<p>Drafting for {truncateMinaPublicKey(currentPlayer)}</p>
 			<SquadSelection player={currentPlayer} />
-			<button on:click={selectSquad} class="_button">Select Squad</button>
+			<button on:click={selectSquad} class="rounded p-2">Select Squad</button>
 		{:else}
 			<div>
 				<h3>Squads</h3>
@@ -111,7 +111,7 @@
 					</div>
 				</div>
 			</div>
-			<button class="_button mt-[30px]" on:click={startGame}>Complete Draft</button>
+			<button class="rounded p-2 mt-[30px]" on:click={startGame}>Complete Draft</button>
 		{/if}
 	</div>
 </div>

--- a/client/src/lib/components/utils/NavItem.svelte
+++ b/client/src/lib/components/utils/NavItem.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	export let href: string | null = null;
+</script>
+
+{#if href}
+	<span
+		class="self-center text-xl font-semibold whitespace-nowrap text-dark py-2 px-4 hover:bg-warmGray-300 ease-in-out transition-all duration-200 rounded"
+		><a {href}><slot /></a></span
+	>
+{:else}
+	<span
+		class="self-center text-xl font-semibold whitespace-nowrap text-dark py-2 px-4 hover:bg-warmGray-300 ease-in-out transition-all duration-200 rounded"
+		><slot /></span
+	>
+{/if}

--- a/client/src/routes/+layout.svelte
+++ b/client/src/routes/+layout.svelte
@@ -1,14 +1,19 @@
 <script>
-	import { Modals, closeModal } from 'svelte-modals';
+	import { Modals, closeModal, openModal } from 'svelte-modals';
 	import '../app.css';
 	import Header from '$lib/components/Header.svelte';
+	import UserModal from '$lib/components/modals/UserModal.svelte';
+
+	const openUserModal = () => {
+		openModal(UserModal, {});
+	};
 </script>
 
 <Modals>
 	<div slot="backdrop" class="backdrop" on:click={closeModal} on:keypress={closeModal} />
 </Modals>
 
-<Header />
+<Header {openUserModal} />
 <main class="container pt-10 bg-light">
 	<slot />
 </main>

--- a/client/src/routes/+page.svelte
+++ b/client/src/routes/+page.svelte
@@ -7,10 +7,10 @@
 	</div>
 </div>
 <div class="flex">
-	<a href="/how-to-play" class="py-10 px-16 mb-4 _button mx-auto bg-primary-light"
+	<a href="/how-to-play" class="py-4 px-5 mb-4 rounded mx-auto bg-primary-light"
 		>Learn How to Play</a
 	>
 </div>
 <div class="flex">
-	<a href="/enter" class="py-10 px-16 _button mx-auto bg-primary">Enter the Arena!</a>
+	<a href="/enter" class="py-4 px-5 rounded mx-auto bg-primary">Enter the Arena!</a>
 </div>

--- a/client/src/routes/enter/+page.svelte
+++ b/client/src/routes/enter/+page.svelte
@@ -8,14 +8,14 @@
 	<p>TODO</p>
 </div>
 <div class="grid grid-cols-2 gap-20 w-3/4 border border-slate-100 mx-auto">
-	<a href="/sandbox" class="text-center card _button">
+	<a href="/sandbox" class="text-center card rounded p-2">
 		<h3 class="text-xl mb-3">Sandbox</h3>
 		<p class="text-slate-600">
 			In sandbox mode, you control both sides. It's a good way to learn the game or practice a
 			strategy. Gameplay is fast and no proofs are generated.
 		</p>
 	</a>
-	<div class="text-center card _button">
+	<div class="text-center card rounded p-2">
 		<h3 class="text-xl mb-3 text-slate-400">Play with a Friend</h3>
 		<p class="text-slate-400">(IN DEVELOPMENT)</p>
 		<p class="text-slate-400">


### PR DESCRIPTION
<img width="1266" alt="image" src="https://github.com/trumpet-zk-ignite-1/mina-arena/assets/36939461/cd6ca2c5-a754-45b6-839d-59387c4686f7">

<img width="594" alt="image" src="https://github.com/trumpet-zk-ignite-1/mina-arena/assets/36939461/047b2e22-6bbb-44b2-b361-566a7c79aa19">


Adding a location where users can manage their keys.  My plan for now is they can toggle between dummy user 1 or their own private key for player 1, and dummy player 2 will continue to be used as the "other" player.

@louiswheeleriv FYI